### PR TITLE
refactor(core-bridge-adapter-sdk): rename BridgeSdk file to BridgeAdapterSdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export abstract class AbstractBridgeAdapter {
     tokens?: { sourceToken: Token; targetToken: Token }
   ): Promise<Token[]>;
 
-  abstract getQuoteDetails(
+  abstract getSwapDetails(
     sourceToken: Token,
     targetToken: Token
   ): Promise<SwapInformation>;

--- a/packages/elasticbottle-core-bridge-adapter-sdk/src/index.ts
+++ b/packages/elasticbottle-core-bridge-adapter-sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { CHAIN_NAMES as SupportedChainNames } from "./constants/ChainNames";
-export { BridgeAdapterSdk } from "./lib/BridgeSdk";
-export type { BridgeAdapterSdkArgs } from "./lib/BridgeSdk";
+export { BridgeAdapterSdk } from "./lib/BridgeAdapterSdk";
+export type { BridgeAdapterSdkArgs } from "./lib/BridgeAdapterSdk";
 export type { BridgeStatus, SolanaOrEvmAccount } from "./types/Bridges";
 export type { ChainName, ChainSourceAndTarget } from "./types/Chain";
 export type { ChainDestType } from "./types/ChainDest";

--- a/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/AbstractBridgeAdapter.ts
+++ b/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/AbstractBridgeAdapter.ts
@@ -8,7 +8,7 @@ import type {
 import type { ChainName, ChainSourceAndTarget } from "../../types/Chain";
 import type { ChainDestType } from "../../types/ChainDest";
 import type { SwapInformation } from "../../types/SwapInformation";
-import type { Token } from "../../types/Token";
+import type { Token, TokenWithAmount } from "../../types/Token";
 
 export abstract class AbstractBridgeAdapter {
   protected sourceChain: ChainName | undefined;
@@ -37,8 +37,8 @@ export abstract class AbstractBridgeAdapter {
     tokens?: { sourceToken: Token; targetToken: Token }
   ): Promise<Token[]>;
 
-  abstract getQuoteDetails(
-    sourceToken: Token,
+  abstract getSwapDetails(
+    sourceToken: TokenWithAmount,
     targetToken: Token
   ): Promise<SwapInformation>;
 

--- a/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/DeBridgeBridgeAdapter.ts
+++ b/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/DeBridgeBridgeAdapter.ts
@@ -245,7 +245,7 @@ export class DeBridgeBridgeAdapter extends AbstractBridgeAdapter {
     return this.tokenList[chain];
   }
 
-  async getQuoteDetails(
+  async getSwapDetails(
     sourceToken: TokenWithAmount,
     targetToken: Token
   ): Promise<SwapInformation> {

--- a/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/MayanBridgeAdapter.ts
+++ b/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/MayanBridgeAdapter.ts
@@ -99,7 +99,7 @@ export class MayanBridgeAdapter extends AbstractBridgeAdapter {
     return this.tokenList[chain];
   }
 
-  async getQuoteDetails(
+  async getSwapDetails(
     sourceToken: TokenWithAmount,
     targetToken: Token
   ): Promise<SwapInformation> {

--- a/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/WormholeBridgeAdapter.ts
+++ b/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapter/WormholeBridgeAdapter.ts
@@ -257,7 +257,7 @@ export class WormholeBridgeAdapter extends AbstractBridgeAdapter {
     throw new Error("Invalid interestedTokenList value");
   }
 
-  getQuoteDetails(
+  getSwapDetails(
     sourceToken: TokenWithAmount,
     targetToken: Token
   ): Promise<SwapInformation> {

--- a/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapterSdk.ts
+++ b/packages/elasticbottle-core-bridge-adapter-sdk/src/lib/BridgeAdapterSdk.ts
@@ -7,7 +7,7 @@ import type {
 import type { ChainName, ChainSourceAndTarget } from "../types/Chain";
 import type { ChainDestType } from "../types/ChainDest";
 import type { SwapInformation } from "../types/SwapInformation";
-import type { Token } from "../types/Token";
+import type { Token, TokenWithAmount } from "../types/Token";
 import { getBridgeAdapters } from "../utils/getBridgeAdapters";
 import { getSourceAndTargetChain } from "../utils/getSourceAndTargetChain";
 import type { AbstractBridgeAdapter } from "./BridgeAdapter/AbstractBridgeAdapter";
@@ -138,10 +138,10 @@ export class BridgeAdapterSdk {
     return Array.from(deduplicatedTokens.values());
   }
 
-  async getSwapInformation(sourceToken: Token, targetToken: Token) {
+  async getSwapInformation(sourceToken: TokenWithAmount, targetToken: Token) {
     const routeInfos = await Promise.allSettled(
       this.bridgeAdapters.map(async (bridgeAdapter) => {
-        return bridgeAdapter.getQuoteDetails(sourceToken, targetToken);
+        return bridgeAdapter.getSwapDetails(sourceToken, targetToken);
       })
     );
     const routes = routeInfos


### PR DESCRIPTION
refactor(core-bridge-adapter-sdk): rename AbstractBridgeAdapter's getQuoteDetail to getSwapDetail to be more aligned with the public Api

# Pull Request

## Stories

- (core-bridge-adapter-sdk): As bridge or DEX developer, I can integrate my bridge with the SDK with less effort with a more aligned language so that the usefulness of the product increases